### PR TITLE
FIX: Allow filtering to work with auto_select

### DIFF
--- a/lib/tty/prompt/list.rb
+++ b/lib/tty/prompt/list.rb
@@ -495,7 +495,7 @@ module TTY
       #
       # @api private
       def only_one_choice?
-        choices.enabled.length == 1
+        choices.length == 1
       end
 
       # Clear screen lines

--- a/lib/tty/prompt/list.rb
+++ b/lib/tty/prompt/list.rb
@@ -491,7 +491,7 @@ module TTY
         choices[@active - 1].value
       end
 
-      # Have we only one valid choice available?
+      # Have we only one choice available? (Not left among others disabled)
       #
       # @api private
       def only_one_choice?


### PR DESCRIPTION
Background:
https://github.com/seawolf/tty-prompt/blob/master/lib/tty/prompt/list.rb#L223-L225

The `List#choices` method only returns a `Choices` object if the list is original and unfiltered (ie. all choices are enabled) - otherwise it returns an array of choices.  So the safest way to determine that there is only one choice available is to check the size property on the return value directly.

### Describe the change
What does this Pull Request do?

### Why are we doing this?
Any related context as to why is this is a desirable change.

### Benefits
How will the library improve?

### Drawbacks
Possible drawbacks applying this change.

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [ ] Tests written & passing locally?
- [ ] Code style checked?
- [ ] Rebased with `master` branch?
- [ ] Documentation updated?
- [ ] Changelog updated?
